### PR TITLE
Add Span within <a> for tabs to easily vertically center with css

### DIFF
--- a/jquery.panelgroup.js
+++ b/jquery.panelgroup.js
@@ -107,7 +107,7 @@
 				that.find(settings.selectors.item).each(function(index) {
 			
 					// Header
-					navItems.push('<li><a href="#" data-tab-index="' + index + '">' + $(this).find(settings.selectors.header).text() + '</a></li>');
+					navItems.push('<li><a href="#" data-tab-index="' + index + '"><span>' + $(this).find(settings.selectors.header).text() + '</span></a></li>');
 					$(this).find(settings.selectors.header).addClass('sr-only').hide();
 
 					// Content


### PR DESCRIPTION
Most designers want the text in the tab to be vertically centered.  I added a span here so that cssers can easily do a fake table-cell and vertical-align: middle;
