### PR TITLE
Updated checking of data-group-type

### DIFF
--- a/jquery.panelgroup.js
+++ b/jquery.panelgroup.js
@@ -29,8 +29,8 @@
 			onlyKeepOneOpen: true
 		},
 		//settings: false,
-		typeOptions: ['tab', 'accordion'],
-		typeDefault: 'tab',
+		typeOptions: ['tabs', 'accordion'],
+		typeDefault: 'tabs',
 		keycodes: {
 			left: 37,
 			up: 38,
@@ -64,7 +64,7 @@
 					var type = $(that).data('group-type');
 
 					// If the type set isn't valid use the default
-					if ( pg.typeOptions.indexOf(type) == '-1' ) {
+					if ( $.inArray(type, options) === -1 ) {
 						type = 'tabs';
 					}
 


### PR DESCRIPTION
no longer using indexOf that requires polyfill in IE8
also fixed typo(ithink) of 'tab' to 'tabs'

The reason behind this - IE8 does not support Array.indexOf without a polyfill.

typo doesn't really affect anything, but I found if confusing because the validation is setting 'tabs' as the default and not 'tab' so I changed that too.